### PR TITLE
Add Evaluate method with workerIndex for thread-safe fitness evaluations

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ public class RosenbrockEvaluator : IFitnessFunctionEvaluator
     public const double A = 1.0;
     public const double B = 100.0;
     
-    public virtual double Evaluate(
+    public double Evaluate(
         ReadOnlySpan<double> genes)
     {
         var x = genes[0];
@@ -78,6 +78,10 @@ public class RosenbrockEvaluator : IFitnessFunctionEvaluator
         
         return Math.Pow(A - x, 2) + B * Math.Pow(y - x * x, 2);
     }
+
+    public double Evaluate(
+        int workerIndex,
+        ReadOnlySpan<double> genes) => Evaluate(genes);
 }
 ```
 

--- a/Src/DotNetDifferentialEvolution/AlgorithmExecutors/AlgorithmExecutor.cs
+++ b/Src/DotNetDifferentialEvolution/AlgorithmExecutors/AlgorithmExecutor.cs
@@ -64,7 +64,9 @@ public class AlgorithmExecutor : IAlgorithmExecutor
                 population: population,
                 trialIndividual: trialIndividual);
 
-            var trialIndividualFfValue = fitnessFunctionEvaluator.Evaluate(trialIndividual);
+            var trialIndividualFfValue = fitnessFunctionEvaluator.Evaluate(
+                workerIndex: workerId,
+                genes: trialIndividual);
 
             _selectionStrategy.Select(
                 individualIndex: i,

--- a/Src/DotNetDifferentialEvolution/DotNetDifferentialEvolution.csproj
+++ b/Src/DotNetDifferentialEvolution/DotNetDifferentialEvolution.csproj
@@ -15,6 +15,7 @@
         <PackageTags>differential-evolution de optimization .net</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <Version>1.1.0</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Src/DotNetDifferentialEvolution/Interfaces/IFitnessFunctionEvaluator.cs
+++ b/Src/DotNetDifferentialEvolution/Interfaces/IFitnessFunctionEvaluator.cs
@@ -9,12 +9,29 @@ public interface IFitnessFunctionEvaluator
 {
     /// <summary>
     /// Evaluates the fitness value of a candidate solution represented by a set of genes.
-    /// The fitness function determines the quality of the solution in the context of the optimization problem.
+    /// This method is typically used during the initialization phase to compute fitness values 
+    /// for the initial population, where differentiation by worker index is not required.
     /// </summary>
     /// <param name="genes">A read-only span of <see cref="double"/> values representing the genes 
     /// (parameters) of the candidate solution to be evaluated.</param>
     /// <returns>A <see cref="double"/> representing the computed fitness value of the given genes.
     /// Lower values indicate better solutions.</returns>
     public double Evaluate(
+        ReadOnlySpan<double> genes);
+    
+    /// <summary>
+    /// Evaluates the fitness value of a candidate solution represented by a set of genes.
+    /// The fitness function determines the quality of the solution in the context of the optimization problem.
+    /// This method is used in multithreaded or distributed execution environments, allowing differentiation 
+    /// of resources or state by worker index.
+    /// </summary>
+    /// <param name="workerIndex">An integer identifier (index) for the worker thread or process.
+    /// This can be used to differentiate resources or manage state during multithreaded execution.</param>
+    /// <param name="genes">A read-only span of <see cref="double"/> values representing the genes 
+    /// (parameters) of the candidate solution to be evaluated.</param>
+    /// <returns>A <see cref="double"/> representing the computed fitness value of the given genes.
+    /// Lower values indicate better solutions.</returns>
+    public double Evaluate(
+        int workerIndex,
         ReadOnlySpan<double> genes);
 }

--- a/Tests/DotNetDifferentialEvolution.Tests.Shared/FitnessFunctionEvaluators/RosenbrockEvaluator.cs
+++ b/Tests/DotNetDifferentialEvolution.Tests.Shared/FitnessFunctionEvaluators/RosenbrockEvaluator.cs
@@ -16,6 +16,10 @@ public class RosenbrockEvaluator : ITestFitnessFunctionEvaluator
         return Math.Pow(A - x, 2) + B * Math.Pow(y - x * x, 2);
     }
 
+    public double Evaluate(
+        int workerIndex,
+        ReadOnlySpan<double> genes) => Evaluate(genes);
+
     public ReadOnlyMemory<double> GetLowerBounds()
     {
         return new[] { -5.0, -5.0 };

--- a/Tests/DotNetDifferentialEvolution.Tests.Shared/FitnessFunctionEvaluators/SimpleSumEvaluator.cs
+++ b/Tests/DotNetDifferentialEvolution.Tests.Shared/FitnessFunctionEvaluators/SimpleSumEvaluator.cs
@@ -30,6 +30,10 @@ public class SimpleSumEvaluator : ITestFitnessFunctionEvaluator
         return sum;
     }
 
+    public double Evaluate(
+        int workerIndex,
+        ReadOnlySpan<double> genes) => Evaluate(genes);
+
     public ReadOnlyMemory<double> GetLowerBounds() => LowerBounds;
 
     public ReadOnlyMemory<double> GetUpperBounds() => UpperBounds;


### PR DESCRIPTION
This pull request introduces an overloaded method Evaluate(int workerIndex, ReadOnlySpan<double> genes) to the IFitnessFunctionEvaluator interface. The new method allows for the evaluation of fitness values in scenarios requiring multithreaded execution while ensuring thread safety.